### PR TITLE
[FIX] Update addons path before starting the instance.

### DIFF
--- a/utils/odoo.go
+++ b/utils/odoo.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"entrypoint/utils"
 	"fmt"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/ini.v1"
@@ -94,10 +95,13 @@ func FilterStrings(list []string, converter envConverter) map[string]string {
 	return converter(list)
 }
 
-// UpdateOdooConfig saves the ini object
+// UpdateOdooConfig saves the ini object and updates the addons paths
 func UpdateOdooConfig(config *ini.File) error {
 	cfgFile := GetConfigFile()
 	if err := config.SaveTo(cfgFile); err != nil {
+		return err
+	}
+	if err := utils.RunAndLogCmdAs("python /home/odoo/getaddons.py /home/odoo/instance/extra_addons", "", nil); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
If there is another configuration file in the extra files it will replace the main file including the addons path, so we need to update it before the instance starts